### PR TITLE
Ensure neutral tongue in/out mapping

### DIFF
--- a/lib/MorphMappers.cs
+++ b/lib/MorphMappers.cs
@@ -118,7 +118,7 @@ namespace FacialTrackerVamPlugin
 
         public static void Tongue()
         {
-            float vInOut = 1 - SRanipalMorphLibrary.Tongue_LongStep1;
+            float vInOut = Mathf.Clamp(SRanipalMorphLibrary.Tongue_LongStep1, 0f, 1f);
 
             float vLength = SRanipalMorphLibrary.Tongue_LongStep2 / factorDivisorTongueStep2;
 


### PR DESCRIPTION
## Summary
- map tongue in/out morph directly from SRanipal value
- clamp tongue in/out to expected morph range

## Testing
- `csc lib/*.cs` *(fails: command not found)*
- `mcs lib/*.cs` *(fails: command not found)*
- `python - <<'PY'
for s in [0.0, -0.2, 0.5, 1.5]:
    vInOut = max(0.0, min(1.0, s))
    print(s, '->', vInOut)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a746c710f8832c80d09703974222b4