### PR TITLE
Fix tongue morph mapping to prevent deformation

### DIFF
--- a/lib/MorphMappers.cs
+++ b/lib/MorphMappers.cs
@@ -118,7 +118,7 @@ namespace FacialTrackerVamPlugin
 
         public static void Tongue()
         {
-            float vInOut = 1 - SRanipalMorphLibrary.Tongue_LongStep1;
+            float vInOut = SRanipalMorphLibrary.Tongue_LongStep1;
 
             float vLength = SRanipalMorphLibrary.Tongue_LongStep2 / factorDivisorTongueStep2;
 
@@ -129,7 +129,7 @@ namespace FacialTrackerVamPlugin
             }
             else if (SRanipalMorphLibrary.Tongue_Down > 0)
             {
-                vRaiseLower = 0 - (SRanipalMorphLibrary.Tongue_Up / factorDivisorTongueUp);
+                vRaiseLower = 0 - (SRanipalMorphLibrary.Tongue_Down / factorDivisorTongueUp);
             }
 
             float vRoll = SRanipalMorphLibrary.Tongue_Roll;
@@ -146,7 +146,7 @@ namespace FacialTrackerVamPlugin
 
             _setMorphValue(DAZMorphLibrary.TongueInOut, vInOut * factorGlobal);
             _setMorphValue(DAZMorphLibrary.TongueLength, vLength * factorGlobal);
-            _setMorphValue(DAZMorphLibrary.TongueRaiseLower, 0.3f+vRaiseLower * factorGlobal);
+            _setMorphValue(DAZMorphLibrary.TongueRaiseLower, vRaiseLower * factorGlobal);
             _setMorphValue(DAZMorphLibrary.TongueRoll2, vRoll * factorGlobal * 2.5f);
             _setMorphValue(DAZMorphLibrary.TongueSideSide, vSideSide * factorGlobal);
 


### PR DESCRIPTION
## Summary
- Correct tongue in-out mapping to align with SRanipal baseline
- Use proper downward value for tongue raise/lower
- Remove constant tongue raise offset for neutral pose

## Testing
- `dotnet build` *(fails: command not found)*
- `csc lib/*.cs` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a74645e634832c8250ecab2e7adda7