### PR TITLE
Add explicit tongue direction morphs

### DIFF
--- a/lib/DAZMorphLibrary.cs
+++ b/lib/DAZMorphLibrary.cs
@@ -40,9 +40,12 @@ namespace FacialTrackerVamPlugin
         public static DAZMorph BrowInnerUp;
         public static DAZMorph BrowOuterUp_L;
         public static DAZMorph BrowOuterUp_R;
-		
-		
-        public static DAZMorph TongueSideSide;		
+
+        public static DAZMorph TongueSideSide;
+        public static DAZMorph TongueLeft;
+        public static DAZMorph TongueRight;
+        public static DAZMorph TongueUp;
+        public static DAZMorph TongueDown;
 
         // Other properties
         private static GenerateDAZMorphsControlUI morphUI;
@@ -137,6 +140,22 @@ namespace FacialTrackerVamPlugin
                 TongueRaiseLower = _initMorph("Tongue Raise-Lower");
                 TongueRoll2 = _initMorph("Tongue Roll 2");
                 TongueSideSide = _initMorph("Tongue Side-Side");
+                TongueLeft = _initMorph(
+                    "Jackaroo.JarModularExpressions.2:/Custom/Atom/Person/Morphs/female/Jackaroo/JaRExpressions1.2/TongueLeft.vmi",
+                    "Tongue Left"
+                );
+                TongueRight = _initMorph(
+                    "Jackaroo.JarModularExpressions.2:/Custom/Atom/Person/Morphs/female/Jackaroo/JaRExpressions1.2/TongueRight.vmi",
+                    "Tongue Right"
+                );
+                TongueUp = _initMorph(
+                    "Jackaroo.JarModularExpressions.2:/Custom/Atom/Person/Morphs/female/Jackaroo/JaRExpressions1.2/TongueUp.vmi",
+                    "Tongue Up"
+                );
+                TongueDown = _initMorph(
+                    "Jackaroo.JarModularExpressions.2:/Custom/Atom/Person/Morphs/female/Jackaroo/JaRExpressions1.2/TongueDown.vmi",
+                    "Tongue Down"
+                );
 				
 				//added
 				JawChew = _initMorph(

--- a/lib/MorphMappers.cs
+++ b/lib/MorphMappers.cs
@@ -150,8 +150,24 @@ namespace FacialTrackerVamPlugin
             _setMorphValue(DAZMorphLibrary.TongueInOut, vInOut * factorGlobal);
             _setMorphValue(DAZMorphLibrary.TongueLength, vLength * factorGlobal);
             _setMorphValue(DAZMorphLibrary.TongueRaiseLower, vRaiseLower * factorGlobal);
+            if (SRanipalMorphLibrary.Tongue_Up > 0)
+            {
+                _setMorphValue(DAZMorphLibrary.TongueUp, SRanipalMorphLibrary.Tongue_Up * factorGlobal);
+            }
+            if (SRanipalMorphLibrary.Tongue_Down > 0)
+            {
+                _setMorphValue(DAZMorphLibrary.TongueDown, SRanipalMorphLibrary.Tongue_Down * factorGlobal);
+            }
             _setMorphValue(DAZMorphLibrary.TongueRoll2, vRoll * factorGlobal * 2.5f);
             _setMorphValue(DAZMorphLibrary.TongueSideSide, vSideSide * factorGlobal);
+            if (SRanipalMorphLibrary.Tongue_Right > 0)
+            {
+                _setMorphValue(DAZMorphLibrary.TongueRight, SRanipalMorphLibrary.Tongue_Right * factorGlobal);
+            }
+            if (SRanipalMorphLibrary.Tongue_Left > 0)
+            {
+                _setMorphValue(DAZMorphLibrary.TongueLeft, SRanipalMorphLibrary.Tongue_Left * factorGlobal);
+            }
 
         }
 


### PR DESCRIPTION
## Summary
- support dedicated tongue left/right/up/down morphs alongside existing mappings
- map SRanipal tongue data to new morphs to enable full tongue articulation

## Testing
- `dotnet --version` *(fails: command not found)*
- `mcs --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a750e98470832ca0d5a4517aa34b65