### PR TITLE
Improve tongue control and jaw forward mapping

### DIFF
--- a/lib/DAZMorphLibrary.cs
+++ b/lib/DAZMorphLibrary.cs
@@ -40,9 +40,12 @@ namespace FacialTrackerVamPlugin
         public static DAZMorph BrowInnerUp;
         public static DAZMorph BrowOuterUp_L;
         public static DAZMorph BrowOuterUp_R;
-		
-		
-        public static DAZMorph TongueSideSide;		
+
+        public static DAZMorph TongueSideSide;
+        public static DAZMorph TongueLeft;
+        public static DAZMorph TongueRight;
+        public static DAZMorph TongueUp;
+        public static DAZMorph TongueDown;
 
         // Other properties
         private static GenerateDAZMorphsControlUI morphUI;
@@ -137,6 +140,22 @@ namespace FacialTrackerVamPlugin
                 TongueRaiseLower = _initMorph("Tongue Raise-Lower");
                 TongueRoll2 = _initMorph("Tongue Roll 2");
                 TongueSideSide = _initMorph("Tongue Side-Side");
+                TongueLeft = _initMorph(
+                    "Jackaroo.JarModularExpressions.2:/Custom/Atom/Person/Morphs/female/Jackaroo/JaRExpressions1.2/TongueLeft.vmi",
+                    "Tongue Left"
+                );
+                TongueRight = _initMorph(
+                    "Jackaroo.JarModularExpressions.2:/Custom/Atom/Person/Morphs/female/Jackaroo/JaRExpressions1.2/TongueRight.vmi",
+                    "Tongue Right"
+                );
+                TongueUp = _initMorph(
+                    "Jackaroo.JarModularExpressions.2:/Custom/Atom/Person/Morphs/female/Jackaroo/JaRExpressions1.2/TongueUp.vmi",
+                    "Tongue Up"
+                );
+                TongueDown = _initMorph(
+                    "Jackaroo.JarModularExpressions.2:/Custom/Atom/Person/Morphs/female/Jackaroo/JaRExpressions1.2/TongueDown.vmi",
+                    "Tongue Down"
+                );
 				
 				//added
 				JawChew = _initMorph(

--- a/lib/MorphMappers.cs
+++ b/lib/MorphMappers.cs
@@ -15,12 +15,17 @@ namespace FacialTrackerVamPlugin
         public SRanipalMorphLibrary sranipalMorphLibrary;
 
         // eventually these might be user-editable via UI controls
-        private static float factorDivisorTongueStep2 = 3;
+        // reduce tongue extension; SRanipal step2 spans roughly 0-1 so divide by
+        // a larger factor to keep the physical tongue length reasonable
+        private static float factorDivisorTongueStep2 = 6f;
         private static float factorDivisorTongueUp = 1;
         private static float factorMultiplierMouthOpen = 1.9f;
         private static float factorMultiplierMouthFrown = 1.5f;
         private static float factorDivisorMouthPouty = 2;
-		private static float factorGlobal = 1f;
+        // global multiplier to allow easy tuning of the overall intensity
+        private static float factorGlobal = 1f;
+        // dedicated multiplier for jaw forward to avoid extreme mouth offsets
+        private static float factorMultiplierJawForward = 1f;
 
         private MVRScript script;
 
@@ -42,7 +47,15 @@ namespace FacialTrackerVamPlugin
 
         public static void JawForward()
         {
-            _setMorphValue(DAZMorphLibrary.JawForward, SRanipalMorphLibrary.Jaw_Forward * factorGlobal * 100);
+            // SRanipal's Jaw_Forward value is already normalized to roughly 0-1
+            // In previous versions a huge multiplier caused the mouth to detach
+            // from the head when the atom moved. Clamp the incoming value and
+            // apply only a mild multiplier so the jaw stays in place.
+            float v = Mathf.Clamp(SRanipalMorphLibrary.Jaw_Forward, -1f, 1f);
+            _setMorphValue(
+                DAZMorphLibrary.JawForward,
+                v * factorMultiplierJawForward * factorGlobal
+            );
         }
 
         public static void MouthOpen()
@@ -150,8 +163,24 @@ namespace FacialTrackerVamPlugin
             _setMorphValue(DAZMorphLibrary.TongueInOut, vInOut * factorGlobal);
             _setMorphValue(DAZMorphLibrary.TongueLength, vLength * factorGlobal);
             _setMorphValue(DAZMorphLibrary.TongueRaiseLower, vRaiseLower * factorGlobal);
+            if (SRanipalMorphLibrary.Tongue_Up > 0)
+            {
+                _setMorphValue(DAZMorphLibrary.TongueUp, SRanipalMorphLibrary.Tongue_Up * factorGlobal);
+            }
+            if (SRanipalMorphLibrary.Tongue_Down > 0)
+            {
+                _setMorphValue(DAZMorphLibrary.TongueDown, SRanipalMorphLibrary.Tongue_Down * factorGlobal);
+            }
             _setMorphValue(DAZMorphLibrary.TongueRoll2, vRoll * factorGlobal * 2.5f);
             _setMorphValue(DAZMorphLibrary.TongueSideSide, vSideSide * factorGlobal);
+            if (SRanipalMorphLibrary.Tongue_Right > 0)
+            {
+                _setMorphValue(DAZMorphLibrary.TongueRight, SRanipalMorphLibrary.Tongue_Right * factorGlobal);
+            }
+            if (SRanipalMorphLibrary.Tongue_Left > 0)
+            {
+                _setMorphValue(DAZMorphLibrary.TongueLeft, SRanipalMorphLibrary.Tongue_Left * factorGlobal);
+            }
 
         }
 


### PR DESCRIPTION
## Summary
- shorten SRanipal tongue length mapping for more natural extension
- clamp jaw forward morph to prevent mouth from detaching when moving

## Testing
- `dotnet --version` *(fails: command not found)*
- `mcs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a750e98470832ca0d5a4517aa34b65