### PR TITLE
Improve tongue control and jaw forward mapping

### DIFF
--- a/lib/DAZMorphLibrary.cs
+++ b/lib/DAZMorphLibrary.cs
@@ -40,9 +40,14 @@ namespace FacialTrackerVamPlugin
         public static DAZMorph BrowInnerUp;
         public static DAZMorph BrowOuterUp_L;
         public static DAZMorph BrowOuterUp_R;
-		
-		
-        public static DAZMorph TongueSideSide;		
+
+        public static DAZMorph TongueSideSide;
+        public static DAZMorph TongueBendTip;
+        public static DAZMorph TongueRoll1;
+        public static DAZMorph TongueCenterDip;
+        public static DAZMorph TongueCurl;
+        public static DAZMorph TongueTwist;
+        public static DAZMorph TongueUpDown;
 
         // Other properties
         private static GenerateDAZMorphsControlUI morphUI;
@@ -137,6 +142,12 @@ namespace FacialTrackerVamPlugin
                 TongueRaiseLower = _initMorph("Tongue Raise-Lower");
                 TongueRoll2 = _initMorph("Tongue Roll 2");
                 TongueSideSide = _initMorph("Tongue Side-Side");
+                TongueBendTip = _initMorph("Tongue Bend Tip");
+                TongueRoll1 = _initMorph("Tongue Roll 1");
+                TongueCenterDip = _initMorph("Tongue Center Dip");
+                TongueCurl = _initMorph("Tongue Curl");
+                TongueTwist = _initMorph("Tongue Twist");
+                TongueUpDown = _initMorph("Tongue Up-Down");
 				
 				//added
 				JawChew = _initMorph(
@@ -164,28 +175,28 @@ namespace FacialTrackerVamPlugin
 
                 BrowDown_L = _initMorph(
                     "Jackaroo.JarModularExpressions.2:/Custom/Atom/Person/Morphs/female/Jackaroo/JaRExpressions1.2/BrowD_L.vmi",
-                    "EyeSquint_L"
-				);
+                    "BrowD_L"
+                );
 
                 BrowDown_R = _initMorph(
                     "Jackaroo.JarModularExpressions.2:/Custom/Atom/Person/Morphs/female/Jackaroo/JaRExpressions1.2/BrowD_R.vmi",
-                    "EyeSquint_L"
-				);
+                    "BrowD_R"
+                );
 
                 BrowInnerUp = _initMorph(
                     "Jackaroo.JarModularExpressions.2:/Custom/Atom/Person/Morphs/female/Jackaroo/JaRExpressions1.2/BrowU_C.vmi",
-                    "EyeSquint_L"
-				);
+                    "BrowU_C"
+                );
 
                 BrowOuterUp_L = _initMorph(
                     "Jackaroo.JarModularExpressions.2:/Custom/Atom/Person/Morphs/female/Jackaroo/JaRExpressions1.2/BrowU_L.vmi",
-                    "EyeSquint_L"
-				);
+                    "BrowU_L"
+                );
 
                 BrowOuterUp_R = _initMorph(
                     "Jackaroo.JarModularExpressions.2:/Custom/Atom/Person/Morphs/female/Jackaroo/JaRExpressions1.2/BrowU_R.vmi",
-                    "EyeSquint_L"
-				);
+                    "BrowU_R"
+                );
             }
             catch (Exception e)
             {

--- a/lib/MorphMappers.cs
+++ b/lib/MorphMappers.cs
@@ -15,12 +15,17 @@ namespace FacialTrackerVamPlugin
         public SRanipalMorphLibrary sranipalMorphLibrary;
 
         // eventually these might be user-editable via UI controls
-        private static float factorDivisorTongueStep2 = 3;
+        // reduce tongue extension; SRanipal step2 spans roughly 0-1 so divide by
+        // a larger factor to keep the physical tongue length reasonable
+        private static float factorDivisorTongueStep2 = 6f;
         private static float factorDivisorTongueUp = 1;
         private static float factorMultiplierMouthOpen = 1.9f;
         private static float factorMultiplierMouthFrown = 1.5f;
         private static float factorDivisorMouthPouty = 2;
-		private static float factorGlobal = 1f;
+        // global multiplier to allow easy tuning of the overall intensity
+        private static float factorGlobal = 1f;
+        // dedicated multiplier for jaw forward to avoid extreme mouth offsets
+        private static float factorMultiplierJawForward = 1f;
 
         private MVRScript script;
 
@@ -42,7 +47,15 @@ namespace FacialTrackerVamPlugin
 
         public static void JawForward()
         {
-            _setMorphValue(DAZMorphLibrary.JawForward, SRanipalMorphLibrary.Jaw_Forward * factorGlobal * 100);
+            // SRanipal's Jaw_Forward value is already normalized to roughly 0-1
+            // In previous versions a huge multiplier caused the mouth to detach
+            // from the head when the atom moved. Clamp the incoming value and
+            // apply only a mild multiplier so the jaw stays in place.
+            float v = Mathf.Clamp(SRanipalMorphLibrary.Jaw_Forward, -1f, 1f);
+            _setMorphValue(
+                DAZMorphLibrary.JawForward,
+                v * factorMultiplierJawForward * factorGlobal
+            );
         }
 
         public static void MouthOpen()
@@ -150,7 +163,13 @@ namespace FacialTrackerVamPlugin
             _setMorphValue(DAZMorphLibrary.TongueInOut, vInOut * factorGlobal);
             _setMorphValue(DAZMorphLibrary.TongueLength, vLength * factorGlobal);
             _setMorphValue(DAZMorphLibrary.TongueRaiseLower, vRaiseLower * factorGlobal);
+            _setMorphValue(DAZMorphLibrary.TongueUpDown, vRaiseLower * 0.5f * factorGlobal);
+            _setMorphValue(DAZMorphLibrary.TongueRoll1, vRoll * factorGlobal * 2.5f);
             _setMorphValue(DAZMorphLibrary.TongueRoll2, vRoll * factorGlobal * 2.5f);
+            _setMorphValue(DAZMorphLibrary.TongueCurl, vRoll * factorGlobal * 2.5f);
+            _setMorphValue(DAZMorphLibrary.TongueBendTip, vRoll * factorGlobal * 2.5f);
+            _setMorphValue(DAZMorphLibrary.TongueCenterDip, vRoll * factorGlobal * 2.5f);
+            _setMorphValue(DAZMorphLibrary.TongueTwist, vRoll * factorGlobal * 2.5f);
             _setMorphValue(DAZMorphLibrary.TongueSideSide, vSideSide * factorGlobal);
 
         }


### PR DESCRIPTION
## Summary
- shorten SRanipal tongue length mapping for more natural extension
- clamp jaw forward morph to prevent mouth from detaching when moving
- correct Jackaroo morph names so optional tongue and brow morphs resolve when installed
- drive built-in tongue bend, roll, curl and twist morphs instead of missing JarModularExpressions entries

## Testing
- `dotnet --version` *(fails: command not found)*
- `mcs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a750e98470832ca0d5a4517aa34b65